### PR TITLE
Use environment variables when building static pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Environment variables for composer container
+COMPOSER_BASENAME=/dashboard
+COMPOSER_ASSETPATH=/composer

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # Mac DS_Store files.
 *.DS_Store
+
+# Docker compose override file
+docker-compose.override.yml

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -5,7 +5,11 @@ WORKDIR /app
 COPY package*.json /app/
 RUN npm install
 COPY ./ /app/
-RUN npm run build
+ARG COMPOSER_ASSETPATH
+ARG COMPOSER_BASENAME
+ENV ASSETPATH ${COMPOSER_ASSETPATH}
+ENV BASENAME ${COMPOSER_BASENAME}
+RUN echo ${BASENAME} && npm run build
 
 # Stage 2, create a production environment.
 FROM nginx:stable-alpine

--- a/README.md
+++ b/README.md
@@ -21,17 +21,21 @@
 
 ## Table of Contents
 
-* [About the Project](#about-the-project)
-  * [Built With](#built-with)
-* [Getting Started](#getting-started)
-  * [Prerequisites](#prerequisites)
-  * [Installation](#installation)
-* [Usage](#usage)
-* [Roadmap](#roadmap)
-* [Contributing](#contributing)
-* [License](#license)
-* [Contact](#contact)
-* [Acknowledgements](#acknowledgements)
+- [Table of Contents](#table-of-contents)
+- [About The Project](#about-the-project)
+  - [Built With](#built-with)
+- [Getting Started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+- [Usage](#usage)
+  - [Local development](#local-development)
+    - [One module at a time](#one-module-at-a-time)
+    - [All modules together](#all-modules-together)
+  - [Docker](#docker)
+- [Contributing](#contributing)
+- [License](#license)
+- [Contact](#contact)
+- [Acknowledgements](#acknowledgements)
 
 ## About The Project
 
@@ -60,7 +64,8 @@ This project uses [React](https://reactjs.org/) and [Yarn](https://yarnpkg.com/)
 
 ### Prerequisites
 
-You need [Yarn](https://yarnpkg.com/) and/or [npm](https://www.npmjs.com/). This guide is written with Yarn in mind.
+You need [Yarn](https://yarnpkg.com/) and/or [npm](https://www.npmjs.com/). This guide is written with Yarn in mind.  
+For usage inside Docker, you will need [Docker](https://docs.docker.com/get-docker/) and [Docker compose](https://docs.docker.com/compose/install/). Please see the [Docker](#docker) section of this document for deployment instructions.
 
 ### Installation
 
@@ -127,6 +132,15 @@ yarn start
 ```
 
 Now follow the steps above for "One module at a time" for each of the modules you wish to work on, including this one.
+
+### Docker
+
+To deploy Composer using a Docker container, set the `BASENAME` environment variable to match the subdirectory you plan on deploying Composer to. If the root of the webserver is to be used, `BASENAME` can be left unset. Alternatively the `.env.example` file can be copied to `.env` and modified to match your configuration.
+
+To build and start the container run
+```sh
+docker-compose up -d --build
+```
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.prod
+      args:
+        - COMPOSER_ASSETPATH
+        - COMPOSER_BASENAME
     ports:
       - '9071:80'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "start": "webpack-dev-server --https --port 9071 --env.assetPath=https://localhost:9071",
-    "build": "webpack --mode=production --env.baseName=/dashboard --env.assetPath=/composer",
+    "build": "webpack --mode=production --env.baseName=${BASENAME} --env.assetPath=${ASSETPATH:=/composer}",
     "analyze": "webpack --mode=production --env.analyze=true",
     "lint": "eslint src --ext js",
     "format": "prettier --write \"./**\"",


### PR DESCRIPTION
Use BASENAME and ASSETPATH environment variables to set the env.baseName and env.assetPath argument values respectively when building the static pages using webpack.

Add instructions for usage in docker.